### PR TITLE
feat: Add path joining optimization for plotter output

### DIFF
--- a/src/lib/pathopt.js
+++ b/src/lib/pathopt.js
@@ -122,6 +122,45 @@ function nearestImprove(polys, startX, startY) {
   return r
 }
 
+// Join polylines that are close together.
+// This assumes polylines are already ordered by a method like nearestNeighbor.
+export function joinPolylines(polylines, tolerance = 0.1) {
+  if (polylines.length < 2) {
+    return polylines.map(p => p.slice());
+  }
+  const tol2 = tolerance * tolerance;
+  const out = [];
+  let currentPoly = polylines[0].slice();
+
+  for (let i = 1; i < polylines.length; i++) {
+    const nextPoly = polylines[i];
+    if (currentPoly.length === 0 || nextPoly.length === 0) {
+      if (currentPoly.length > 0) {
+        out.push(currentPoly);
+      }
+      currentPoly = nextPoly.slice();
+      continue;
+    }
+
+    const endOfCurrent = currentPoly[currentPoly.length - 1];
+    const startOfNext = nextPoly[0];
+
+    if (dist2(endOfCurrent, startOfNext) < tol2) {
+      // Using concat instead of spread for potentially better performance with large arrays
+      currentPoly = currentPoly.concat(nextPoly.slice(1));
+    } else {
+      out.push(currentPoly);
+      currentPoly = nextPoly.slice();
+    }
+  }
+
+  if (currentPoly.length > 0) {
+    out.push(currentPoly);
+  }
+
+  return out;
+}
+
 export function orderPolylines(polylines, method = 'none', startX = 0, startY = 0) {
   if (method === 'none') return polylines.map(p => p.slice())
   if (method === 'improve' || method === 'nearest+improve') return nearestImprove(polylines, startX, startY)

--- a/src/lib/previewWorker.js
+++ b/src/lib/previewWorker.js
@@ -1,12 +1,13 @@
 // Web Worker: off-main-thread renderer for previews
-// Receives { id, layers, doc, mdiCache, bitmaps, quality }
-// Sends { id, type:'progress', progress } and { id, type:'done', outputs } or { id, type:'error', message }
+// Receives { id, layers, doc, mdiCache, bitmaps, quality, optimizeJoin }
+// Sends { id, type:'progress', progress } and { id, type:'done', outputs, paths } or { id, type:'error', message }
 
 import { computeRendered } from './renderer.js'
 import { polylineToPath } from './geometry.js'
+import { orderPolylines, joinPolylines } from './pathopt.js'
 
 self.onmessage = async (e) => {
-  const { id, layers, doc, mdiCache, bitmaps, quality } = e.data || {}
+  const { id, layers, doc, mdiCache, bitmaps, quality, optimizeJoin } = e.data || {}
   try {
     const outputs = computeRendered(layers || [], doc || {}, mdiCache || {}, bitmaps || {}, quality || 1, (p) => {
       let pct = 0
@@ -21,7 +22,18 @@ self.onmessage = async (e) => {
       pct = Math.max(0, Math.min(1, pct))
       self.postMessage({ id, type: 'progress', progress: pct, detail })
     })
-    const paths = outputs.map(({ layer, polylines }) => ({ layer, d: (polylines||[]).map(polylineToPath).join(' ') }))
+    const paths = outputs.map(({ layer, polylines }) => {
+      let polys = polylines || []
+      // The preview can optionally apply path ordering and joining to reflect the final export.
+      // This is heavier, so it's gated by the same settings as G-code export.
+      if (doc.optimize && doc.optimize !== 'none') {
+        polys = orderPolylines(polys, doc.optimize, doc.startX, doc.startY)
+      }
+      if (optimizeJoin) {
+        polys = joinPolylines(polys)
+      }
+      return { layer, d: polys.map(polylineToPath).join(' ') }
+    })
     self.postMessage({ id, type: 'done', outputs, paths })
   } catch (err) {
     self.postMessage({ id, type: 'error', message: String(err && err.message || err) })


### PR DESCRIPTION
This commit introduces a new optimization option to join contiguous line segments into a single path for both SVG and G-code exports. This is designed to make the output more efficient for pen plotters by minimizing unnecessary pen-up and pen-down movements.

Key changes:
- A new `joinPolylines` function has been added to `src/lib/pathopt.js` to merge adjacent polylines that are within a given tolerance.
- A "Join Paths" checkbox has been added to the G-code settings UI, allowing users to enable or disable this feature. The state is controlled by the `doc.optimizeJoin` property.
- The G-code and SVG export functions (`downloadGcode`, `downloadSVGs`, `downloadLayerSvg`) in `src/App.jsx` have been updated to apply the `joinPolylines` optimization after the existing path ordering optimization.
- The preview worker (`src/lib/previewWorker.js`) has been updated to use the same optimization logic, ensuring the preview accurately reflects the final exported output.